### PR TITLE
msharpe/ForkPuppetLabsAccountsRepo4AnsibleUsage_CHG0300977

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,14 @@
+galaxy_info:
+  author: Mike Sharpe
+  description: Puppetlabs accounts module
+  license: license (GPLv2)
+
+  min_ansible_version: 2.9
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+
+  galaxy_tags: []
+dependencies: []


### PR DESCRIPTION
```
Added meta folder so puppet-accounts repo can be used with ansible